### PR TITLE
Handle incorrect JSQ_33 route mapping

### DIFF
--- a/cmd/pathgtfsrt.go
+++ b/cmd/pathgtfsrt.go
@@ -85,7 +85,8 @@ func run(ctx context.Context) error {
 		}
 	} else if *useHTTPSourceAPI {
 		fmt.Println("Source API: HTTP")
-		sourceClient = pathgtfsrt.NewHttpSourceClient(*timeoutPeriod)
+		httpClient := &http.Client{Timeout: *timeoutPeriod}
+		sourceClient = pathgtfsrt.NewHttpSourceClient(httpClient)
 	} else {
 		fmt.Println("Source API: gRPC")
 		grpcClient, err := pathgtfsrt.NewGrpcSourceClient(*timeoutPeriod)

--- a/grpc.go
+++ b/grpc.go
@@ -73,6 +73,7 @@ func (client *GrpcSourceClient) GetTrainsAtStation(ctx context.Context, station 
 	}
 	var trains []Train
 	for _, train := range response.UpcomingTrains {
+		applyRouteQaToTrain(train)
 		trains = append(trains, train)
 	}
 	return trains, nil

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,151 @@
+package pathgtfsrt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/go-cmp/cmp"
+	sourceapi "github.com/jamespfennell/path-train-gtfs-realtime/proto/sourceapi"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestSourceHttpGetTrainsAtStation(t *testing.T) {
+	for _, tc := range []struct {
+		testName     string
+		station      sourceapi.Station
+		jsonFilePath string
+		trains       []Train
+	}{
+		{
+			testName:     "Hoboken",
+			station:      sourceapi.Station_HOBOKEN,
+			jsonFilePath: "mock_data/source_http_hoboken.json",
+			trains: []Train{
+				{
+					Route:            sourceapi.Route_JSQ_33_HOB,
+					Direction:        sourceapi.Direction_TO_NY,
+					LineName:         "33rd Street via Hoboken",
+					ProjectedArrival: mkTimestampFromRfc3339("2023-12-23T05:36:15Z"),
+					LastUpdated:      mkTimestampFromRfc3339("2023-12-23T05:35:44Z"),
+				},
+				{
+					Route:            sourceapi.Route_JSQ_33_HOB,
+					Direction:        sourceapi.Direction_TO_NY,
+					LineName:         "33rd Street via Hoboken",
+					ProjectedArrival: mkTimestampFromRfc3339("2023-12-23T06:01:30Z"),
+					LastUpdated:      mkTimestampFromRfc3339("2023-12-23T05:35:44Z"),
+				},
+				{
+					Route:            sourceapi.Route_JSQ_33_HOB,
+					Direction:        sourceapi.Direction_TO_NJ,
+					LineName:         "Journal Square via Hoboken",
+					ProjectedArrival: mkTimestampFromRfc3339("2023-12-23T05:36:15Z"),
+					LastUpdated:      mkTimestampFromRfc3339("2023-12-23T05:35:44Z"),
+				},
+				{
+					Route:            sourceapi.Route_JSQ_33_HOB,
+					Direction:        sourceapi.Direction_TO_NJ,
+					LineName:         "Journal Square via Hoboken",
+					ProjectedArrival: mkTimestampFromRfc3339("2023-12-23T06:02:44Z"),
+					LastUpdated:      mkTimestampFromRfc3339("2023-12-23T05:35:44Z"),
+				},
+			},
+		},
+		{
+			// See: https://github.com/mrazza/path-data/issues/22
+			testName:     "Handle incorrect route mapping of JSQ_33 route",
+			station:      sourceapi.Station_NEWPORT,
+			jsonFilePath: "mock_data/source_http_newport.json",
+			trains: []Train{
+				{
+					Route:            sourceapi.Route_JSQ_33,
+					Direction:        sourceapi.Direction_TO_NY,
+					LineName:         "33rd Street",
+					ProjectedArrival: mkTimestampFromRfc3339("2023-12-27T00:09:21Z"),
+					LastUpdated:      mkTimestampFromRfc3339("2023-12-27T00:01:24Z"),
+				},
+			},
+		},
+	} {
+		mockHttpClient := MockSourceHTTPClient{StationToJsonFilePath: map[sourceapi.Station]string{tc.station: tc.jsonFilePath}}
+		client := NewHttpSourceClient(mockHttpClient)
+		ctx := context.Background()
+		gotTrains, err := client.GetTrainsAtStation(ctx, tc.station)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(&gotTrains, &tc.trains, protocmp.Transform()); diff != "" {
+			t.Errorf("GTFS realtime feed got != want, diff=%s", diff)
+		}
+	}
+}
+
+func mkTimestampFromRfc3339(timeString string) *timestamp.Timestamp {
+	timeObj, err := time.Parse(time.RFC3339, timeString)
+	if err != nil {
+		return nil
+	}
+	value := timestamp.Timestamp{Seconds: timeObj.Unix()}
+	return &value
+}
+
+func getStationNameFromURL(urlStr string) (string, error) {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return "", err
+	}
+
+	segments := strings.Split(parsedURL.Path, "/")
+	// The segments slice will contain ["", "v1", "stations", "newark", "realtime", ""]
+	// So, the station name is the fourth element (index 3)
+	if len(segments) > 4 {
+		return segments[3], nil
+	}
+	return "", fmt.Errorf("invalid URL format")
+}
+
+type MockSourceHTTPClient struct {
+	JSONFilePath          string
+	StationToJsonFilePath map[sourceapi.Station]string
+}
+
+func (m MockSourceHTTPClient) Get(reqUrl string) (*http.Response, error) {
+	statioName, err := getStationNameFromURL(reqUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	station := sourceapi.Station(sourceapi.Station_value[statioName])
+	jsonFilePath, ok := m.StationToJsonFilePath[station]
+	if !ok {
+		return nil, fmt.Errorf("no JSON file path found for station %s", station)
+	}
+
+	// Read data from the specified JSON file
+	file, err := os.Open(jsonFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mock the response
+	r := ioutil.NopCloser(bytes.NewReader(data))
+	return &http.Response{
+		StatusCode: 200,
+		Body:       r,
+	}, nil
+}

--- a/httpclient.go
+++ b/httpclient.go
@@ -1,0 +1,7 @@
+package pathgtfsrt
+
+import "net/http"
+
+type HttpClient interface {
+	Get(url string) (resp *http.Response, err error)
+}

--- a/mock_data/source_http_hoboken.json
+++ b/mock_data/source_http_hoboken.json
@@ -1,0 +1,48 @@
+{
+  "upcomingTrains": [
+    {
+      "lineName": "33rd Street via Hoboken",
+      "headsign": "33rd Street via Hoboken",
+      "route": "JSQ_33_HOB",
+      "routeDisplayName": "Journal Square - 33rd Street (via Hoboken)",
+      "direction": "TO_NY",
+      "lineColors": ["#4D92FB", "#FF9900"],
+      "status": "ON_TIME",
+      "projectedArrival": "2023-12-23T05:36:15Z",
+      "lastUpdated": "2023-12-23T05:35:44Z"
+    },
+    {
+      "lineName": "33rd Street via Hoboken",
+      "headsign": "33rd Street via Hoboken",
+      "route": "JSQ_33_HOB",
+      "routeDisplayName": "Journal Square - 33rd Street (via Hoboken)",
+      "direction": "TO_NY",
+      "lineColors": ["#4D92FB", "#FF9900"],
+      "status": "ON_TIME",
+      "projectedArrival": "2023-12-23T06:01:30Z",
+      "lastUpdated": "2023-12-23T05:35:44Z"
+    },
+    {
+      "lineName": "Journal Square via Hoboken",
+      "headsign": "Journal Square via Hoboken",
+      "route": "JSQ_33_HOB",
+      "routeDisplayName": "33rd Street (via Hoboken) - Journal Square",
+      "direction": "TO_NJ",
+      "lineColors": ["#4D92FB", "#FF9900"],
+      "status": "ON_TIME",
+      "projectedArrival": "2023-12-23T05:36:15Z",
+      "lastUpdated": "2023-12-23T05:35:44Z"
+    },
+    {
+      "lineName": "Journal Square via Hoboken",
+      "headsign": "Journal Square via Hoboken",
+      "route": "JSQ_33_HOB",
+      "routeDisplayName": "33rd Street (via Hoboken) - Journal Square",
+      "direction": "TO_NJ",
+      "lineColors": ["#4D92FB", "#FF9900"],
+      "status": "ON_TIME",
+      "projectedArrival": "2023-12-23T06:02:44Z",
+      "lastUpdated": "2023-12-23T05:35:44Z"
+    }
+  ]
+}

--- a/mock_data/source_http_newport.json
+++ b/mock_data/source_http_newport.json
@@ -1,0 +1,15 @@
+{
+  "upcomingTrains": [
+    {
+      "lineName": "33rd Street",
+      "headsign": "33rd Street",
+      "route": "JSQ_33_HOB",
+      "routeDisplayName": "Journal Square - 33rd Street (via Hoboken)",
+      "direction": "TO_NY",
+      "lineColors": ["#FF9900"],
+      "status": "ON_TIME",
+      "projectedArrival": "2023-12-27T00:09:21Z",
+      "lastUpdated": "2023-12-27T00:01:24Z"
+    }
+  ]
+}

--- a/panynj.go
+++ b/panynj.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,10 +18,6 @@ const (
 	paNyNjApiUrl      = "https://www.panynj.gov/bin/portauthority/ridepath.json"
 	cacheValidityTime = 10 * time.Second
 )
-
-type HttpClient interface {
-	Get(url string) (resp *http.Response, err error)
-}
 
 type cachedContent struct {
 	timestamp time.Time

--- a/qa.go
+++ b/qa.go
@@ -1,0 +1,18 @@
+package pathgtfsrt
+
+import (
+	"strings"
+
+	sourceapi "github.com/jamespfennell/path-train-gtfs-realtime/proto/sourceapi"
+)
+
+const (
+	ViaHobokenSuffix = "via hoboken"
+)
+
+func applyRouteQaToTrain(train *sourceapi.GetUpcomingTrainsResponse_UpcomingTrain) {
+	normalizedLineName := strings.ToLower(train.LineName)
+	if train.Route == sourceapi.Route_JSQ_33_HOB && !strings.HasSuffix(normalizedLineName, ViaHobokenSuffix) {
+		train.Route = sourceapi.Route_JSQ_33
+	}
+}

--- a/qa_test.go
+++ b/qa_test.go
@@ -1,0 +1,57 @@
+package pathgtfsrt
+
+import (
+	"github.com/google/go-cmp/cmp"
+	sourceapi "github.com/jamespfennell/path-train-gtfs-realtime/proto/sourceapi"
+	"google.golang.org/protobuf/testing/protocmp"
+	"testing"
+)
+
+func TestRouteQa(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		train *sourceapi.GetUpcomingTrainsResponse_UpcomingTrain
+		want  *sourceapi.GetUpcomingTrainsResponse_UpcomingTrain
+	}{
+		{
+			name: "no change",
+			train: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33_HOB,
+				LineName: "33rd Street via Hoboken",
+			},
+			want: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33_HOB,
+				LineName: "33rd Street via Hoboken",
+			},
+		},
+		{
+			name: "no change, lower case",
+			train: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33_HOB,
+				LineName: "33rd street via hoboken",
+			},
+			want: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33_HOB,
+				LineName: "33rd street via hoboken",
+			},
+		},
+		{
+			name: "change",
+			train: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33_HOB,
+				LineName: "33rd Street",
+			},
+			want: &sourceapi.GetUpcomingTrainsResponse_UpcomingTrain{
+				Route:    sourceapi.Route_JSQ_33,
+				LineName: "33rd Street",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			applyRouteQaToTrain(tc.train)
+			if diff := cmp.Diff(tc.want, tc.train, protocmp.Transform()); diff != "" {
+				t.Errorf("applyRouteQaToTrain() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The upstream `path-data` API returns the wrong route for `JSQ_33`. I've opened an issue with more details here: https://github.com/mrazza/path-data/issues/22. In summary, the line name is correct ("33rd Street", for NY bound trains) but the route and route description will point to `JSQ_33_HOB`.

## Solution

Pending an upstream fix, we can recognize this case by inspecting the `LineName` that is returned, which is correct. If the line name ends in "via Hoboken", it is OK to keep the route as `JSQ_33_HOB`; otherwise, we change it to `JSQ_33`.

## Changes

- Add `qa.go`, which applies the check/transformation described above
- Run QA logic in `http` and `grpc` clients
- Similar to the `panynj` client, construct the `http` client with a passed in `HttpClient`, allowing for easier testing

## Testing
- Add unit tests for `qa.go`
- Add unit tests for `http.go` with mocked JSON data