### PR TITLE
Add run arguments to status page

### DIFF
--- a/cmd/index.html
+++ b/cmd/index.html
@@ -1,39 +1,44 @@
 <!doctype html>
 
 <html lang="en">
-<head>
-    <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
     <title>PATH Train GTFS Realtime</title>
 
-<style>
-body {
-  font-family: Helvetica, sans-serif;
-  line-height: 1.4em;
-}
+    <style>
+      body {
+        font-family: Helvetica, sans-serif;
+        line-height: 1.4em;
+      }
 
-h1 {
-  text-align: center;
-}
-ul {
-	font-size: 1.2em;
-}
+      h1 {
+        text-align: center;
+      }
+      ul {
+        font-size: 1.2em;
+      }
 
-li {
-	margin: 8px; 
-}
+      li {
+        margin: 8px;
+      }
+    </style>
+  </head>
 
-</style>
-</head>
-
-<body>
-<div style="width: 600px; margin: 10px auto;">
-	<h1>PATH Train GTFS Realtime</h1>
-	<ul>
-		<li>Build #%s</li>
-		<li><a href="./gtfsrt">Data feed</a></li>
-		<li><a href="./metrics">Prometheus metrics endpoint</a></li>
-		<li><a href="https://github.com/jamespfennell/path-train-gtfs-realtime/">Github repository</a></li>
-	</ul>
-</div>
-</body>
+  <body>
+    <div style="width: 600px; margin: 10px auto">
+      <h1>PATH Train GTFS Realtime</h1>
+      <ul>
+        <li><b>Build:</b> #%s</li>
+        <li><b>Run arguments:</b> %s</li>
+        <li><b>Source data API:</b> %s</li>
+        <li><a href="./gtfsrt">Data feed</a></li>
+        <li><a href="./metrics">Prometheus metrics endpoint</a></li>
+        <li>
+          <a href="https://github.com/jamespfennell/path-train-gtfs-realtime/"
+            >Github repository</a
+          >
+        </li>
+      </ul>
+    </div>
+  </body>
 </html>

--- a/cmd/index.html
+++ b/cmd/index.html
@@ -29,8 +29,10 @@
       <h1>PATH Train GTFS Realtime</h1>
       <ul>
         <li><b>Build:</b> #%s</li>
-        <li><b>Run arguments:</b> %s</li>
-        <li><b>Source data API:</b> %s</li>
+        <li><b>Data source API:</b> %s</li>
+        <li><b>Port:</b> %d</li>
+        <li><b>Update preiod:</b> %s</li>
+        <li><b>Timeout preiod:</b> %s</li>
         <li><a href="./gtfsrt">Data feed</a></li>
         <li><a href="./metrics">Prometheus metrics endpoint</a></li>
         <li>

--- a/cmd/pathgtfsrt.go
+++ b/cmd/pathgtfsrt.go
@@ -26,6 +26,21 @@ var timeoutPeriod = flag.Duration("timeout_period", 5*time.Second, "maximum dura
 var useHTTPSourceAPI = flag.Bool("use_http_source_api", false, "use the HTTP source API instead of the default gRPC API")
 var usePanynjAPI = flag.Bool("use_panynj_api", false, "use the Panynj API instead of the default path-data API")
 
+func formatCommandLineArgs() string {
+	return fmt.Sprintf("port=%d, update_period=%s, timeout_period=%s, use_http_source_api=%t, use_panynj_api=%t",
+		*port, *updatePeriod, *timeoutPeriod, *useHTTPSourceAPI, *usePanynjAPI)
+}
+
+func getApiName() string {
+	if *usePanynjAPI {
+		return "Panynj API"
+	} else if *useHTTPSourceAPI {
+		return "HTTP path-data API"
+	} else {
+		return "gRPC path-data API"
+	}
+}
+
 const (
 	minPanynjUpdatePeriod = 15 * time.Second
 )
@@ -109,7 +124,10 @@ func run(ctx context.Context) error {
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, indexHTMLPage, pathgtfsrt.BuildNumber)
+	fmt.Fprintf(w, indexHTMLPage,
+		pathgtfsrt.BuildNumber,
+		formatCommandLineArgs(),
+		getApiName())
 }
 
 func recordUpdate(msg *gtfs.FeedMessage, errs []error) {

--- a/cmd/pathgtfsrt.go
+++ b/cmd/pathgtfsrt.go
@@ -26,12 +26,7 @@ var timeoutPeriod = flag.Duration("timeout_period", 5*time.Second, "maximum dura
 var useHTTPSourceAPI = flag.Bool("use_http_source_api", false, "use the HTTP source API instead of the default gRPC API")
 var usePanynjAPI = flag.Bool("use_panynj_api", false, "use the Panynj API instead of the default path-data API")
 
-func formatCommandLineArgs() string {
-	return fmt.Sprintf("port=%d, update_period=%s, timeout_period=%s, use_http_source_api=%t, use_panynj_api=%t",
-		*port, *updatePeriod, *timeoutPeriod, *useHTTPSourceAPI, *usePanynjAPI)
-}
-
-func getApiName() string {
+func getDataSourceApiName() string {
 	if *usePanynjAPI {
 		return "Panynj API"
 	} else if *useHTTPSourceAPI {
@@ -126,8 +121,10 @@ func run(ctx context.Context) error {
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, indexHTMLPage,
 		pathgtfsrt.BuildNumber,
-		formatCommandLineArgs(),
-		getApiName())
+		getDataSourceApiName(),
+		*port,
+		*updatePeriod,
+		*timeoutPeriod)
 }
 
 func recordUpdate(msg *gtfs.FeedMessage, errs []error) {


### PR DESCRIPTION
Based on a suggestion from @jamespfennell on #7, this PR adds what command line arguments are used for the server on the status page (similar to the build number). It also displays the source API explicitly, since this might not be obvious from the command line flags alone (i.e. since the default is the gRPC path-data API if no CLI options are given).